### PR TITLE
Extend options for scatter plots

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ initialCommands := """
 
 publishMavenStyle := true
 
+parallelExecution in Test := false
+
 // Publishing not enabled yet.
 publishTo <<= version { (v: String) =>
   val nexus = "https://oss.sonatype.org/"

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ publishMavenStyle := true
 
 parallelExecution in Test := false
 
+logBuffered in Test := false
+
 // Publishing not enabled yet.
 publishTo <<= version { (v: String) =>
   val nexus = "https://oss.sonatype.org/"

--- a/src/main/scala/co/theasi/plotly/Color.scala
+++ b/src/main/scala/co/theasi/plotly/Color.scala
@@ -1,0 +1,14 @@
+package co.theasi.plotly
+
+case class Color(
+  r: Int,
+  g: Int,
+  b: Int,
+  a: Double
+)
+
+case object Color {
+  def rgb(r: Int, g: Int, b: Int): Color = Color(r, g, b, 1.0)
+  def rgba(r: Int, g: Int, b: Int, a: Double): Color =
+    Color(r, g, b, a)
+}

--- a/src/main/scala/co/theasi/plotly/Plot.scala
+++ b/src/main/scala/co/theasi/plotly/Plot.scala
@@ -1,7 +1,7 @@
 package co.theasi.plotly
 
 case class Plot(
-    val series: List[Series] = List.empty,
+    val series: Vector[Series] = Vector.empty,
     val layout: Layout = Layout()
 ) {
 
@@ -12,7 +12,7 @@ case class Plot(
   ): Plot = {
     val xsAsPType = xs.map { implicitly[Writable[X]].toPType }
     val ysAsPType = ys.map { implicitly[Writable[Y]].toPType }
-    copy(series = Scatter(xsAsPType, ysAsPType, options) :: series)
+    copy(series = series :+ Scatter(xsAsPType, ysAsPType, options))
   }
 
   def withBar[X: Writable, Y: Writable](
@@ -21,14 +21,14 @@ case class Plot(
   ): Plot = {
     val xsAsPType = xs.map { implicitly[Writable[X]].toPType }
     val ysAsPType = ys.map { implicitly[Writable[Y]].toPType }
-    copy(series = Bar(xsAsPType, ysAsPType, BarOptions()) :: series)
+    copy(series = series :+ Bar(xsAsPType, ysAsPType, BarOptions()))
   }
 
   def withBox[X: Writable](
     xs: Iterable[X]
   ): Plot = {
     val xsAsPType = xs.map { implicitly[Writable[X]].toPType }
-    copy(series = Box(xsAsPType, BoxOptions()) :: series)
+    copy(series = series :+ Box(xsAsPType, BoxOptions()))
   }
 
 }

--- a/src/main/scala/co/theasi/plotly/ScatterOptions.scala
+++ b/src/main/scala/co/theasi/plotly/ScatterOptions.scala
@@ -1,0 +1,73 @@
+package co.theasi.plotly
+
+case class ScatterOptions(
+  name: Option[String],
+  xAxis: Option[Int],
+  yAxis: Option[Int],
+  mode: Seq[ScatterMode.Value],
+  marker: MarkerOptions
+) extends SeriesOptions[ScatterOptions] {
+
+  def name(newName: String) = copy(name = Some(newName))
+  def xAxis(newXAxis: Int) = copy(xAxis = Some(newXAxis))
+  def yAxis(newYAxis: Int): ScatterOptions = copy(yAxis = Some(newYAxis))
+
+  def mode(newMode: ScatterMode.Value, rest: ScatterMode.Value*)
+  : ScatterOptions = mode(newMode +: rest)
+  def mode(newModes: Iterable[ScatterMode.Value]): ScatterOptions =
+    copy(mode = newModes.toSeq)
+
+  def marker(newMarker: MarkerOptions): ScatterOptions =
+    copy(marker = newMarker)
+
+}
+
+object ScatterOptions {
+  def apply(): ScatterOptions = ScatterOptions(
+    name = None,
+    xAxis = None,
+    yAxis = None,
+    mode = Seq.empty,
+    marker = MarkerOptions()
+  )
+}
+
+object ScatterMode extends Enumeration {
+  val Marker = Value("markers")
+  val Line = Value("lines")
+  val Text = Value("text")
+}
+
+case class MarkerOptions(
+  size: Option[Int],
+  color: Option[Color],
+  lineWidth: Option[Int],
+  lineColor: Option[Color]
+) {
+
+  def size(newSize: Int): MarkerOptions = copy(size = Some(newSize))
+  def color(newColor: Color): MarkerOptions =
+    copy(color = Some(newColor))
+  def color(r: Int, g: Int, b: Int, a: Double): MarkerOptions =
+    color(Color.rgba(r, g, b, a))
+  def color(r: Int, g: Int, b: Int): MarkerOptions =
+    color(r, g, b, 1.0)
+
+  def lineWidth(newLineWidth: Int): MarkerOptions =
+    copy(lineWidth = Some(newLineWidth))
+  def lineColor(newLineColor: Color): MarkerOptions =
+    copy(lineColor = Some(newLineColor))
+  def lineColor(r: Int, g: Int, b: Int, a: Double): MarkerOptions =
+    lineColor(Color.rgba(r, g, b, a))
+  def lineColor(r: Int, g: Int, b: Int): MarkerOptions =
+    lineColor(r, g, b, 1.0)
+}
+
+object MarkerOptions {
+  def apply(): MarkerOptions = MarkerOptions(
+    size = None,
+    color = None,
+    lineWidth = None,
+    lineColor = None
+  )
+}

--- a/src/main/scala/co/theasi/plotly/ScatterOptions.scala
+++ b/src/main/scala/co/theasi/plotly/ScatterOptions.scala
@@ -5,6 +5,7 @@ case class ScatterOptions(
   xAxis: Option[Int],
   yAxis: Option[Int],
   mode: Seq[ScatterMode.Value],
+  text: Option[TextValue],
   marker: MarkerOptions
 ) extends SeriesOptions[ScatterOptions] {
 
@@ -17,6 +18,15 @@ case class ScatterOptions(
   def mode(newModes: Iterable[ScatterMode.Value]): ScatterOptions =
     copy(mode = newModes.toSeq)
 
+  def text(newText: String): ScatterOptions =
+    copy(text = Some(StringText(newText)))
+  def text[T: Writable](newText: Iterable[T]): ScatterOptions = {
+    val textAsPType = newText.map { implicitly[Writable[T]].toPType }
+    copy(text = Some(IterableText(textAsPType)))
+  }
+  def textSrc(src: String): ScatterOptions =
+    copy(text = Some(SrcText(src)))
+
   def marker(newMarker: MarkerOptions): ScatterOptions =
     copy(marker = newMarker)
 
@@ -28,6 +38,7 @@ object ScatterOptions {
     xAxis = None,
     yAxis = None,
     mode = Seq.empty,
+    text = None,
     marker = MarkerOptions()
   )
 }

--- a/src/main/scala/co/theasi/plotly/Series.scala
+++ b/src/main/scala/co/theasi/plotly/Series.scala
@@ -1,7 +1,8 @@
 package co.theasi.plotly
 
 sealed trait Series {
-  val options: SeriesOptions
+  type OptionType <: SeriesOptions[OptionType]
+  val options: OptionType
 
   def xsAs[T : Readable]: Iterable[T] = {
     this match {
@@ -23,30 +24,39 @@ sealed trait Series {
   }
 }
 
-sealed abstract class Series1D[X <: PType] extends Series {
+sealed abstract class Series1D[
+    X <: PType]
+extends Series {
   val xs: Iterable[X]
 }
 
 case class Box[X <: PType](
     val xs: Iterable[X],
-    val options: BoxOptions)
-extends Series1D[X]
-
-sealed abstract class Series2D[X <: PType, Y <: PType] extends Series {
-  val xs: Iterable[X]
-  val ys: Iterable[Y]
-  val options: SeriesOptions
+    override val options: BoxOptions)
+extends Series1D[X] {
+  type OptionType = BoxOptions
 }
 
-case class Scatter[X <: PType, Y <: PType](
+sealed abstract class Series2D[
+    X <: PType,
+    Y <: PType]
+extends Series {
+  val xs: Iterable[X]
+  val ys: Iterable[Y]
+  val options: OptionType
+}
+
+case class Scatter[
+    X <: PType,
+    Y <: PType](
     val xs: Iterable[X],
     val ys: Iterable[Y],
     override val options: ScatterOptions)
-extends Series2D[X, Y]
+extends Series2D[X, Y] { type OptionType = ScatterOptions }
 
 
 case class Bar[X <: PType, Y <: PType](
     val xs: Iterable[X],
     val ys: Iterable[Y],
     override val options: BarOptions)
-extends Series2D[X, Y]
+extends Series2D[X, Y] { type OptionType = BarOptions }

--- a/src/main/scala/co/theasi/plotly/Series.scala
+++ b/src/main/scala/co/theasi/plotly/Series.scala
@@ -4,6 +4,8 @@ sealed trait Series {
   type OptionType <: SeriesOptions[OptionType]
   val options: OptionType
 
+  def options(newOptions: OptionType): Series
+
   def xsAs[T : Readable]: Iterable[T] = {
     this match {
       case s: Series1D[_] =>
@@ -35,6 +37,9 @@ case class Box[X <: PType](
     override val options: BoxOptions)
 extends Series1D[X] {
   type OptionType = BoxOptions
+
+  override def options(newOptions: BoxOptions): Box[X] =
+    copy(options = newOptions)
 }
 
 sealed abstract class Series2D[
@@ -52,11 +57,21 @@ case class Scatter[
     val xs: Iterable[X],
     val ys: Iterable[Y],
     override val options: ScatterOptions)
-extends Series2D[X, Y] { type OptionType = ScatterOptions }
+extends Series2D[X, Y] {
+  type OptionType = ScatterOptions
+
+  override def options(newOptions: ScatterOptions): Scatter[X, Y] =
+    copy(options = newOptions)
+}
 
 
 case class Bar[X <: PType, Y <: PType](
     val xs: Iterable[X],
     val ys: Iterable[Y],
     override val options: BarOptions)
-extends Series2D[X, Y] { type OptionType = BarOptions }
+extends Series2D[X, Y] {
+  type OptionType = BarOptions
+
+  override def options(newOptions: BarOptions): Bar[X, Y] =
+    copy(options = newOptions)
+}

--- a/src/main/scala/co/theasi/plotly/SeriesOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SeriesOptions.scala
@@ -21,38 +21,6 @@ case class BoxOptions(
 }
 
 
-case class ScatterOptions(
-  name: Option[String],
-  xAxis: Option[Int],
-  yAxis: Option[Int],
-  mode: Seq[ScatterMode.Value],
-  marker: MarkerOptions
-) extends SeriesOptions[ScatterOptions] {
-
-  def name(newName: String) = copy(name = Some(newName))
-  def xAxis(newXAxis: Int) = copy(xAxis = Some(newXAxis))
-  def yAxis(newYAxis: Int): ScatterOptions = copy(yAxis = Some(newYAxis))
-
-  def mode(newMode: ScatterMode.Value, rest: ScatterMode.Value*)
-  : ScatterOptions = mode(newMode +: rest)
-  def mode(newModes: Iterable[ScatterMode.Value]): ScatterOptions =
-    copy(mode = newModes.toSeq)
-
-  def marker(newMarker: MarkerOptions): ScatterOptions =
-    copy(marker = newMarker)
-
-}
-
-object ScatterOptions {
-  def apply(): ScatterOptions = ScatterOptions(
-    name = None,
-    xAxis = None,
-    yAxis = None,
-    mode = Seq.empty,
-    marker = MarkerOptions()
-  )
-}
-
 case class BarOptions(
   name: Option[String] = None,
   xAxis: Option[Int] = None,
@@ -63,44 +31,4 @@ case class BarOptions(
   def xAxis(newXAxis: Int) = copy(xAxis = Some(newXAxis))
   def yAxis(newYAxis: Int): BarOptions = copy(yAxis = Some(newYAxis))
 
-}
-
-object ScatterMode extends Enumeration {
-  val Marker = Value("markers")
-  val Line = Value("lines")
-  val Text = Value("text")
-}
-
-case class MarkerOptions(
-  size: Option[Int],
-  color: Option[Color],
-  lineWidth: Option[Int],
-  lineColor: Option[Color]
-) {
-
-  def size(newSize: Int): MarkerOptions = copy(size = Some(newSize))
-  def color(newColor: Color): MarkerOptions =
-    copy(color = Some(newColor))
-  def color(r: Int, g: Int, b: Int, a: Double): MarkerOptions =
-    color(Color.rgba(r, g, b, a))
-  def color(r: Int, g: Int, b: Int): MarkerOptions =
-    color(r, g, b, 1.0)
-
-  def lineWidth(newLineWidth: Int): MarkerOptions =
-    copy(lineWidth = Some(newLineWidth))
-  def lineColor(newLineColor: Color): MarkerOptions =
-    copy(lineColor = Some(newLineColor))
-  def lineColor(r: Int, g: Int, b: Int, a: Double): MarkerOptions =
-    lineColor(Color.rgba(r, g, b, a))
-  def lineColor(r: Int, g: Int, b: Int): MarkerOptions =
-    lineColor(r, g, b, 1.0)
-}
-
-object MarkerOptions {
-  def apply(): MarkerOptions = MarkerOptions(
-    size = None,
-    color = None,
-    lineWidth = None,
-    lineColor = None
-  )
 }

--- a/src/main/scala/co/theasi/plotly/SeriesOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SeriesOptions.scala
@@ -16,7 +16,8 @@ extends SeriesOptions
 case class ScatterOptions(
   name: String = "",
   xAxis: Int = 0,
-  yAxis: Int = 0
+  yAxis: Int = 0,
+  mode: Set[ScatterMode.Value] = Set.empty
 )
 extends SeriesOptions
 
@@ -26,3 +27,9 @@ case class BarOptions(
   yAxis: Int = 0
 )
 extends SeriesOptions
+
+object ScatterMode extends Enumeration {
+  val Marker = Value("markers")
+  val Line = Value("lines")
+  val Text = Value("text")
+}

--- a/src/main/scala/co/theasi/plotly/SeriesOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SeriesOptions.scala
@@ -32,9 +32,9 @@ case class ScatterOptions(
   def xAxis(newXAxis: Int) = copy(xAxis = Some(newXAxis))
   def yAxis(newYAxis: Int): ScatterOptions = copy(yAxis = Some(newYAxis))
 
-  def mode(newMode: ScatterMode.Value): ScatterOptions =
-    modes(Seq(newMode))
-  def modes(newModes: Iterable[ScatterMode.Value]): ScatterOptions =
+  def mode(newMode: ScatterMode.Value, rest: ScatterMode.Value*)
+  : ScatterOptions = mode(newMode +: rest)
+  def mode(newModes: Iterable[ScatterMode.Value]): ScatterOptions =
     copy(mode = newModes.toSeq)
 
 }

--- a/src/main/scala/co/theasi/plotly/SeriesOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SeriesOptions.scala
@@ -1,32 +1,64 @@
 package co.theasi.plotly
 
-sealed trait SeriesOptions {
-  val name: String
-  val xAxis: Int
-  val yAxis: Int
+trait SeriesOptions[T <: SeriesOptions[T]] {
+  val name: Option[String]
+  val xAxis: Option[Int]
+  val yAxis: Option[Int]
+
+  def name(newName: String): T
+  def xAxis(newXAxis: Int): T
+  def yAxis(newYAxis: Int): T
 }
 
 case class BoxOptions(
-  name: String = "",
-  xAxis: Int = 0,
-  yAxis: Int = 0
-)
-extends SeriesOptions
+  name: Option[String] = None,
+  xAxis: Option[Int] = None,
+  yAxis: Option[Int] = None
+) extends SeriesOptions[BoxOptions] {
+  def name(newName: String) = copy(name = Some(newName))
+  def xAxis(newXAxis: Int) = copy(xAxis = Some(newXAxis))
+  def yAxis(newYAxis: Int): BoxOptions = copy(yAxis = Some(newYAxis))
+}
+
 
 case class ScatterOptions(
-  name: String = "",
-  xAxis: Int = 0,
-  yAxis: Int = 0,
-  mode: Set[ScatterMode.Value] = Set.empty
-)
-extends SeriesOptions
+  name: Option[String],
+  xAxis: Option[Int],
+  yAxis: Option[Int],
+  mode: Seq[ScatterMode.Value]
+) extends SeriesOptions[ScatterOptions] {
+
+  def name(newName: String) = copy(name = Some(newName))
+  def xAxis(newXAxis: Int) = copy(xAxis = Some(newXAxis))
+  def yAxis(newYAxis: Int): ScatterOptions = copy(yAxis = Some(newYAxis))
+
+  def mode(newMode: ScatterMode.Value): ScatterOptions =
+    modes(Seq(newMode))
+  def modes(newModes: Iterable[ScatterMode.Value]): ScatterOptions =
+    copy(mode = newModes.toSeq)
+
+}
+
+object ScatterOptions {
+  def apply(): ScatterOptions = ScatterOptions(
+    name = None,
+    xAxis = None,
+    yAxis = None,
+    mode = Seq.empty
+  )
+}
 
 case class BarOptions(
-  name: String = "",
-  xAxis: Int = 0,
-  yAxis: Int = 0
-)
-extends SeriesOptions
+  name: Option[String] = None,
+  xAxis: Option[Int] = None,
+  yAxis: Option[Int] = None
+) extends SeriesOptions[BarOptions] {
+
+  def name(newName: String) = copy(name = Some(newName))
+  def xAxis(newXAxis: Int) = copy(xAxis = Some(newXAxis))
+  def yAxis(newYAxis: Int): BarOptions = copy(yAxis = Some(newYAxis))
+
+}
 
 object ScatterMode extends Enumeration {
   val Marker = Value("markers")

--- a/src/main/scala/co/theasi/plotly/SeriesOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SeriesOptions.scala
@@ -25,7 +25,8 @@ case class ScatterOptions(
   name: Option[String],
   xAxis: Option[Int],
   yAxis: Option[Int],
-  mode: Seq[ScatterMode.Value]
+  mode: Seq[ScatterMode.Value],
+  marker: MarkerOptions
 ) extends SeriesOptions[ScatterOptions] {
 
   def name(newName: String) = copy(name = Some(newName))
@@ -37,6 +38,9 @@ case class ScatterOptions(
   def mode(newModes: Iterable[ScatterMode.Value]): ScatterOptions =
     copy(mode = newModes.toSeq)
 
+  def marker(newMarker: MarkerOptions): ScatterOptions =
+    copy(marker = newMarker)
+
 }
 
 object ScatterOptions {
@@ -44,7 +48,8 @@ object ScatterOptions {
     name = None,
     xAxis = None,
     yAxis = None,
-    mode = Seq.empty
+    mode = Seq.empty,
+    marker = MarkerOptions()
   )
 }
 
@@ -64,4 +69,38 @@ object ScatterMode extends Enumeration {
   val Marker = Value("markers")
   val Line = Value("lines")
   val Text = Value("text")
+}
+
+case class MarkerOptions(
+  size: Option[Int],
+  color: Option[Color],
+  lineWidth: Option[Int],
+  lineColor: Option[Color]
+) {
+
+  def size(newSize: Int): MarkerOptions = copy(size = Some(newSize))
+  def color(newColor: Color): MarkerOptions =
+    copy(color = Some(newColor))
+  def color(r: Int, g: Int, b: Int, a: Double): MarkerOptions =
+    color(Color.rgba(r, g, b, a))
+  def color(r: Int, g: Int, b: Int): MarkerOptions =
+    color(r, g, b, 1.0)
+
+  def lineWidth(newLineWidth: Int): MarkerOptions =
+    copy(lineWidth = Some(newLineWidth))
+  def lineColor(newLineColor: Color): MarkerOptions =
+    copy(lineColor = Some(newLineColor))
+  def lineColor(r: Int, g: Int, b: Int, a: Double): MarkerOptions =
+    lineColor(Color.rgba(r, g, b, a))
+  def lineColor(r: Int, g: Int, b: Int): MarkerOptions =
+    lineColor(r, g, b, 1.0)
+}
+
+object MarkerOptions {
+  def apply(): MarkerOptions = MarkerOptions(
+    size = None,
+    color = None,
+    lineWidth = None,
+    lineColor = None
+  )
 }

--- a/src/main/scala/co/theasi/plotly/Writable.scala
+++ b/src/main/scala/co/theasi/plotly/Writable.scala
@@ -5,10 +5,10 @@ trait Writable[T] {
 }
 
 trait WritableImplicits {
-  implicit object WritableFloat extends Writable[Float] {
-    def toPType(x: Float) = PDouble(x.toDouble)
-  }
   implicit object WritableDouble extends Writable[Double] {
     def toPType(x: Double) = PDouble(x)
+  }
+  implicit object WritableInt extends Writable[Int] {
+    def toPType(x: Int) = PInt(x)
   }
 }

--- a/src/main/scala/co/theasi/plotly/Writable.scala
+++ b/src/main/scala/co/theasi/plotly/Writable.scala
@@ -11,4 +11,7 @@ trait WritableImplicits {
   implicit object WritableInt extends Writable[Int] {
     def toPType(x: Int) = PInt(x)
   }
+  implicit object WritableString extends Writable[String] {
+    def toPType(x: String) = PString(x)
+  }
 }

--- a/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
@@ -4,7 +4,8 @@ import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.JsonDSL._
 
-import co.theasi.plotly.{ScatterOptions, ScatterMode, MarkerOptions, Color}
+import co.theasi.plotly.{ScatterOptions, ScatterMode, MarkerOptions,
+  Color, TextValue, StringText, IterableText, SrcText}
 
 object OptionsWriter {
 
@@ -16,6 +17,7 @@ object OptionsWriter {
     ("yaxis" -> yAxis) ~
     ("name" -> options.name) ~
     ("mode" -> scatterModeToJson(options.mode)) ~
+    textToJson(options.text) ~
     ("marker" -> markerOptionsToJson(options.marker))
   }
 
@@ -25,8 +27,10 @@ object OptionsWriter {
       case i => root + (i+1).toString
     }
 
-  private def scatterModeToJson(mode: Seq[ScatterMode.Value]): String =
-    if (mode.isEmpty) { "none" } else { mode.map { _.toString.toLowerCase }.mkString("+") }
+  private def scatterModeToJson(mode: Seq[ScatterMode.Value])
+  : Option[String] =
+    if (mode.isEmpty) { None }
+    else { Some(mode.map { _.toString.toLowerCase }.mkString("+")) }
 
   private def markerOptionsToJson(options: MarkerOptions): JObject = {
     ("color" -> options.color.map(colorToJson)) ~
@@ -38,6 +42,15 @@ object OptionsWriter {
       )
     )
   }
+
+  private def textToJson(text: Option[TextValue]): JObject =
+    text match {
+      case Some(StringText(s)) => ("text" -> s)
+      case Some(SrcText(s)) => ("textsrc" -> s)
+      case Some(IterableText(v)) =>
+        throw new IllegalStateException("No")
+      case None => JObject()
+    }
 
   private def colorToJson(color: Color): String =
     s"rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})"

--- a/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
@@ -4,7 +4,7 @@ import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.JsonDSL._
 
-import co.theasi.plotly.{ScatterOptions, ScatterMode}
+import co.theasi.plotly.{ScatterOptions, ScatterMode, MarkerOptions, Color}
 
 object OptionsWriter {
 
@@ -15,7 +15,8 @@ object OptionsWriter {
     ("xaxis" -> xAxis) ~
     ("yaxis" -> yAxis) ~
     ("name" -> options.name) ~
-    ("mode" -> scatterModeToJson(options.mode))
+    ("mode" -> scatterModeToJson(options.mode)) ~
+    ("marker" -> markerOptionsToJson(options.marker))
   }
 
   private def axisToJson(axis: Option[Int], root: String): Option[String] =
@@ -26,4 +27,19 @@ object OptionsWriter {
 
   private def scatterModeToJson(mode: Seq[ScatterMode.Value]): String =
     if (mode.isEmpty) { "none" } else { mode.map { _.toString.toLowerCase }.mkString("+") }
+
+  private def markerOptionsToJson(options: MarkerOptions): JObject = {
+    ("color" -> options.color.map(colorToJson)) ~
+    ("size" -> options.size) ~
+    ("line" ->
+      (
+        ("color" -> options.lineColor.map(colorToJson)) ~
+        ("width" -> options.lineWidth)
+      )
+    )
+  }
+
+  private def colorToJson(color: Color): String =
+    s"rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})"
+
 }

--- a/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
@@ -18,9 +18,12 @@ object OptionsWriter {
     ("mode" -> scatterModeToJson(options.mode))
   }
 
-  private def axisToJson(axis: Int, root: String): String =
-    if (axis == 0) { root } else { root + (axis + 1).toString }
+  private def axisToJson(axis: Option[Int], root: String): Option[String] =
+    axis.map {
+      case 0 => root
+      case i => root + (i+1).toString
+    }
 
-  private def scatterModeToJson(mode: Set[ScatterMode.Value]): String =
+  private def scatterModeToJson(mode: Seq[ScatterMode.Value]): String =
     if (mode.isEmpty) { "none" } else { mode.map { _.toString.toLowerCase }.mkString("+") }
 }

--- a/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
@@ -4,16 +4,23 @@ import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.JsonDSL._
 
-import co.theasi.plotly.ScatterOptions
+import co.theasi.plotly.{ScatterOptions, ScatterMode}
 
 object OptionsWriter {
 
   def scatterOptionsToJson(options: ScatterOptions): JObject = {
     val xAxis = axisToJson(options.xAxis, "x")
     val yAxis = axisToJson(options.yAxis, "y")
-    ("xaxis" -> xAxis) ~ ("yaxis" -> yAxis) ~ ("name" -> options.name)
+
+    ("xaxis" -> xAxis) ~
+    ("yaxis" -> yAxis) ~
+    ("name" -> options.name) ~
+    ("mode" -> scatterModeToJson(options.mode))
   }
 
   private def axisToJson(axis: Int, root: String): String =
     if (axis == 0) { root } else { root + (axis + 1).toString }
+
+  private def scatterModeToJson(mode: Set[ScatterMode.Value]): String =
+    if (mode.isEmpty) { "none" } else { mode.map { _.toString.toLowerCase }.mkString("+") }
 }

--- a/src/main/scala/co/theasi/plotly/writer/PlotReader.scala
+++ b/src/main/scala/co/theasi/plotly/writer/PlotReader.scala
@@ -19,7 +19,7 @@ object PlotReader {
       case series: JObject => SeriesReader.fromJson(series)
       case r => throw new UnexpectedServerResponse(
         s"Bad response from server for Plot object: $r")
-    }
+    }.toVector
     new Plot(plotSeries)
   }
 }

--- a/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
@@ -7,7 +7,7 @@ import org.json4s.JsonDSL._
 import co.theasi.plotly.{SeriesOptions, ScatterOptions, BarOptions, BoxOptions}
 
 object SeriesWriter {
-  def toJson(srcs: List[String], options: SeriesOptions)
+  def toJson(srcs: List[String], options: SeriesOptions[_])
   : JValue = {
     options match {
       case o: ScatterOptions => scatterToJson(srcs, o)

--- a/src/main/scala/co/theasi/plotly/writer/TextValue.scala
+++ b/src/main/scala/co/theasi/plotly/writer/TextValue.scala
@@ -1,0 +1,7 @@
+package co.theasi.plotly
+
+sealed trait TextValue
+
+case class StringText(value: String) extends TextValue
+case class IterableText[T <: PType](value: Iterable[T]) extends TextValue
+case class SrcText(value: String) extends TextValue

--- a/src/test/scala/co/theasi/plotly/ScatterOptionsSpec.scala
+++ b/src/test/scala/co/theasi/plotly/ScatterOptionsSpec.scala
@@ -1,0 +1,33 @@
+package co.theasi.plotly
+
+import org.scalatest._
+
+class ScatterOptionsSpec extends FlatSpec with Matchers {
+
+  "ScatterOptions" should "support setting mode" in {
+    import ScatterMode._
+    val opts0 = ScatterOptions().mode(Marker, Line)
+    opts0.mode should contain allOf (Marker, Line)
+    val opts1 = ScatterOptions().mode(Seq(Marker, Text))
+    opts1.mode should contain allOf (Marker, Text)
+  }
+
+  "MarkerOptions" should "support setting color" in {
+    val opts0 = MarkerOptions().color(Color.rgba(1, 2, 3, 0.2))
+    opts0.color.get shouldEqual Color.rgba(1, 2, 3, 0.2)
+    val opts1 = MarkerOptions().color(10, 11, 12, 0.4)
+    opts1.color.get shouldEqual Color.rgba(10, 11, 12, 0.4)
+    val opts2 = MarkerOptions().color(20, 21, 22)
+    opts2.color.get shouldEqual Color.rgb(20, 21, 22)
+  }
+
+  it should "support setting the line color" in {
+    val opts0 = MarkerOptions().lineColor(Color.rgba(1, 2, 3, 0.2))
+    opts0.lineColor.get shouldEqual Color.rgba(1, 2, 3, 0.2)
+    val opts1 = MarkerOptions().lineColor(10, 11, 12, 0.4)
+    opts1.lineColor.get shouldEqual Color.rgba(10, 11, 12, 0.4)
+    val opts2 = MarkerOptions().lineColor(20, 21, 22)
+    opts2.lineColor.get shouldEqual Color.rgb(20, 21, 22)
+  }
+
+}

--- a/src/test/scala/co/theasi/plotly/testing/tags/Slow.java
+++ b/src/test/scala/co/theasi/plotly/testing/tags/Slow.java
@@ -1,0 +1,9 @@
+package co.theasi.plotly;
+
+import java.lang.annotation.*;
+import org.scalatest.TagAnnotation ;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Slow {}

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -1,0 +1,61 @@
+package co.theasi.plotly.writer
+
+import org.json4s._
+import org.json4s.native.JsonMethods._
+
+import org.scalatest._
+
+import co.theasi.plotly._
+
+class PlotWriterSpec extends FlatSpec with Matchers {
+
+  /*implicit val testServer = new Server {
+    override val credentials = Credentials("PlotlyImageTest", "786r5mecv0")
+    override val url = "https://api.plot.ly/v2"
+  }*/
+  val testX1 = Vector(1.0, 2.0, 3.0)
+  val testX2 = Vector(1, 2, 3)
+  val testY1 = Vector(4.0, 5.0, 7.0)
+
+  def checkTestX1(arr: JValue) = {
+    val JArray(response) = arr
+    response.toVector shouldEqual testX1.map { JDouble }
+  }
+
+  def checkTestX2(arr: JValue) = {
+    val JArray(response) = arr
+    response.toVector shouldEqual testX2.map { JInt(_) }
+  }
+
+  def checkTestY1(arr: JValue) = {
+    val JArray(response) = arr
+    response.toVector shouldEqual testY1.map { JDouble }
+  }
+
+  def getJsonForPlotFile(plotFile: PlotFile): JValue = {
+    val endPoint = s"plots/${plotFile.fileId}/content"
+    val req = Api.get(endPoint, Seq("inline_data" -> "true"))
+    Api.despatchAndInterpret(req)
+  }
+
+  "draw" should "draw a basic scatter plot" in {
+    val p = Plot().withScatter(testX1, testY1)
+    val plotFile = PlotWriter.draw(p, "test-123")
+
+    // Verify that the plot is correct
+    val jsonResponse = getJsonForPlotFile(plotFile)
+    val series = (jsonResponse \ "data")(0)
+    checkTestX1(series \ "x")
+    checkTestY1(series \ "y")
+  }
+
+  it should "draw a scatter plot with mixed Int/Double" in {
+    val p = Plot().withScatter(testX2, testY1)
+    val plotFile = PlotWriter.draw(p, "test-124")
+
+    val jsonResponse = getJsonForPlotFile(plotFile)
+    val series = (jsonResponse \ "data")(0)
+    checkTestX2(series \ "x")
+    checkTestY1(series \ "y")
+  }
+}

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -60,8 +60,10 @@ class PlotWriterSpec extends FlatSpec with Matchers {
   }
 
   it should "draw a scatter plot with set mode" in {
-    val options0 = ScatterOptions(mode = Set(ScatterMode.Line))
-    val options1 = ScatterOptions(mode = Set(ScatterMode.Marker, ScatterMode.Line))
+    val options0 = ScatterOptions(
+      mode = Set(ScatterMode.Line))
+    val options1 = ScatterOptions(
+      mode = Set(ScatterMode.Marker, ScatterMode.Line))
     val p = Plot()
       .withScatter(testX1, testY1, options0)
       .withScatter(testX1, testY1, options1)

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest._
 
 import co.theasi.plotly._
 
+@Slow
 class PlotWriterSpec extends FlatSpec with Matchers {
 
   implicit val testServer = new Server {

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -60,10 +60,9 @@ class PlotWriterSpec extends FlatSpec with Matchers {
   }
 
   it should "draw a scatter plot with set mode" in {
-    val options0 = ScatterOptions(
-      mode = Set(ScatterMode.Line))
-    val options1 = ScatterOptions(
-      mode = Set(ScatterMode.Marker, ScatterMode.Line))
+    val options0 = ScatterOptions().mode(ScatterMode.Line)
+    val options1 = ScatterOptions()
+      .modes(List(ScatterMode.Marker, ScatterMode.Line))
     val p = Plot()
       .withScatter(testX1, testY1, options0)
       .withScatter(testX1, testY1, options1)

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -9,10 +9,10 @@ import co.theasi.plotly._
 
 class PlotWriterSpec extends FlatSpec with Matchers {
 
-  /*implicit val testServer = new Server {
+  implicit val testServer = new Server {
     override val credentials = Credentials("PlotlyImageTest", "786r5mecv0")
-    override val url = "https://api.plot.ly/v2"
-  }*/
+    override val url = "https://api.plot.ly/v2/"
+  }
   val testX1 = Vector(1.0, 2.0, 3.0)
   val testX2 = Vector(1, 2, 3)
   val testY1 = Vector(4.0, 5.0, 7.0)

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -62,7 +62,7 @@ class PlotWriterSpec extends FlatSpec with Matchers {
   it should "draw a scatter plot with set mode" in {
     val options0 = ScatterOptions().mode(ScatterMode.Line)
     val options1 = ScatterOptions()
-      .modes(List(ScatterMode.Marker, ScatterMode.Line))
+      .mode(List(ScatterMode.Marker, ScatterMode.Line))
     val p = Plot()
       .withScatter(testX1, testY1, options0)
       .withScatter(testX1, testY1, options1)

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -76,4 +76,26 @@ class PlotWriterSpec extends FlatSpec with Matchers {
     val JString(mode1) = series1 \ "mode"
     mode1 should (equal("lines+markers") or equal("markers+lines"))
   }
+
+  it should "draw a scatter plot with marker options" in {
+    val options0 = ScatterOptions().marker(
+      MarkerOptions()
+        .size(22)
+        .color(5, 10, 15, 0.5)
+        .lineWidth(6)
+        .lineColor(1, 2, 3, 0.1)
+    )
+    val p = Plot().withScatter(testX1, testY1, options0)
+    val plotFile = PlotWriter.draw(p, "test-126")
+
+    val jsonResponse = getJsonForPlotFile(plotFile)
+    val series0 = (jsonResponse \ "data")(0)
+    val marker = (series0 \ "marker")
+    val JString(color) = (marker \ "color")
+    color.replace(" ", "") shouldEqual "rgba(5,10,15,0.5)"
+    (marker \ "size") shouldEqual JInt(22)
+    (marker \ "line" \ "width") shouldEqual JInt(6)
+    val JString(lineColor) = (marker \ "line" \ "color")
+    lineColor.replace(" ", "") shouldEqual "rgba(1,2,3,0.1)"
+  }
 }

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -17,6 +17,7 @@ class PlotWriterSpec extends FlatSpec with Matchers {
   val testX1 = Vector(1.0, 2.0, 3.0)
   val testX2 = Vector(1, 2, 3)
   val testY1 = Vector(4.0, 5.0, 7.0)
+  val testText1 = Vector("A", "B", "C")
 
   def checkTestX1(arr: JValue) = {
     val JArray(response) = arr
@@ -31,6 +32,11 @@ class PlotWriterSpec extends FlatSpec with Matchers {
   def checkTestY1(arr: JValue) = {
     val JArray(response) = arr
     response.toVector shouldEqual testY1.map { JDouble }
+  }
+
+  def checkTestText1(arr: JValue) = {
+    val JArray(response) = arr
+    response.toVector shouldEqual testText1.map { JString }
   }
 
   def getJsonForPlotFile(plotFile: PlotFile): JValue = {
@@ -98,5 +104,21 @@ class PlotWriterSpec extends FlatSpec with Matchers {
     (marker \ "line" \ "width") shouldEqual JInt(6)
     val JString(lineColor) = (marker \ "line" \ "color")
     lineColor.replace(" ", "") shouldEqual "rgba(1,2,3,0.1)"
+  }
+
+  it should "draw a scatter plot with text options" in {
+    val options0 = ScatterOptions().text(testText1)
+    val options1 = ScatterOptions().text("hello")
+
+    val p = Plot()
+      .withScatter(testX1, testY1, options0)
+      .withScatter(testX1, testY1, options1)
+
+    val plotFile = PlotWriter.draw(p, "test-127")
+    val jsonResponse = getJsonForPlotFile(plotFile)
+    val series0 = (jsonResponse \ "data")(0)
+    checkTestText1(series0 \ "text")
+    val series1 = (jsonResponse \ "data")(1)
+    (series1 \ "text") shouldEqual JString("hello")
   }
 }

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -58,4 +58,21 @@ class PlotWriterSpec extends FlatSpec with Matchers {
     checkTestX2(series \ "x")
     checkTestY1(series \ "y")
   }
+
+  it should "draw a scatter plot with set mode" in {
+    val options0 = ScatterOptions(mode = Set(ScatterMode.Line))
+    val options1 = ScatterOptions(mode = Set(ScatterMode.Marker, ScatterMode.Line))
+    val p = Plot()
+      .withScatter(testX1, testY1, options0)
+      .withScatter(testX1, testY1, options1)
+    val plotFile = PlotWriter.draw(p, "test-125")
+
+    val jsonResponse = getJsonForPlotFile(plotFile)
+    val series0 = (jsonResponse \ "data")(0)
+    val JString(mode0) = series0 \ "mode"
+    mode0 should (equal("lines+markers") or equal("markers+lines"))
+    val series1 = (jsonResponse \ "data")(1)
+    val JString(mode1) = series1 \ "mode"
+    mode1 shouldEqual "lines"
+  }
 }

--- a/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/PlotWriterSpec.scala
@@ -72,9 +72,9 @@ class PlotWriterSpec extends FlatSpec with Matchers {
     val jsonResponse = getJsonForPlotFile(plotFile)
     val series0 = (jsonResponse \ "data")(0)
     val JString(mode0) = series0 \ "mode"
-    mode0 should (equal("lines+markers") or equal("markers+lines"))
+    mode0 shouldEqual "lines"
     val series1 = (jsonResponse \ "data")(1)
     val JString(mode1) = series1 \ "mode"
-    mode1 shouldEqual "lines"
+    mode1 should (equal("lines+markers") or equal("markers+lines"))
   }
 }


### PR DESCRIPTION
This PR should make it possible to draw reasonable scatter plots now. It also adds unit tests for scatter plots.

The syntax is:

```
import co.theasi.plotly
import util.Random

val n = 500

val xs = (0 until n).map { i => Random.nextDouble }
val ys0 = (0 until n).map { i => Random.nextDouble + 2.0 }
val ys1 = (0 until n).map { i => Random.nextDouble - 2.0 }

val p = Plot()
  .withScatter(xs, ys0,
    ScatterOptions()
      .mode(ScatterMode.Marker)
      .name("Above")
      .marker(
        MarkerOptions()
          .size(10)
          .color(152, 0, 0, 0.8)
          .lineWidth(2)
          .lineColor(0, 0, 0)))

  .withScatter(xs, ys1,
    ScatterOptions()
      .mode(ScatterMode.Marker)
      .name("Below")
      .marker(
        MarkerOptions()
          .size(10)
          .color(255, 182, 193, 0.9)
          .lineWidth(2)))

draw(p, "styled-scatter", writer.FileOptions(overwrite=true))
```